### PR TITLE
Consumer contract test added to the repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
             <version>4.4.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>au.com.dius.pact</groupId>
+            <artifactId>consumer</artifactId>
+            <version>4.2.9</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -105,6 +111,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <env>${env.dev}</env>
+                                <pact.rootDir>src/test/resources/pacts</pact.rootDir>
                             </systemPropertyVariables>
                             <argLine>-Xmx1024m</argLine>
                             <argLine>-XX:MaxPermSize=512m</argLine>
@@ -127,6 +134,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <env>${env.qa}</env>
+                                <pact.rootDir>./src/test/resources/pacts</pact.rootDir>
                             </systemPropertyVariables>
                             <argLine>-Xmx1024m</argLine>
                             <argLine>-XX:MaxPermSize=512m</argLine>

--- a/src/test/java/com/sandeep/api/tests/contract/pact/PactConsumerTest.java
+++ b/src/test/java/com/sandeep/api/tests/contract/pact/PactConsumerTest.java
@@ -1,0 +1,62 @@
+package com.sandeep.api.tests.contract.pact;
+
+import au.com.dius.pact.consumer.PactVerificationResult;
+import au.com.dius.pact.consumer.model.MockProviderConfig;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import com.sandeep.api.base.ApiBase;
+import com.sandeep.api.tests.contract.pact.util.PactUtil;
+import io.restassured.response.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.Test;
+
+import static au.com.dius.pact.consumer.ConsumerPactRunnerKt.runConsumerTest;
+import static au.com.dius.pact.core.model.PactSpecVersion.V4;
+import static com.sandeep.api.base.EndPoints.USERS;
+import static io.restassured.http.Method.GET;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+@Slf4j
+public class PactConsumerTest {
+    private Response response;
+
+    @Test
+    public void testConsumerContractForGetAllUsers() {
+        // Arrange
+        RequestResponsePact responsePact = PactUtil.getGetRequestResponsePact("reqResUserConsumer",
+                "reqResUserProvider",
+                "ReqRes user fetch test",
+                format("/api%s", USERS));
+
+        MockProviderConfig pactConsumerConfig = MockProviderConfig.httpConfig("localhost",
+                8090,
+                V4);
+
+        PactVerificationResult pactConsumerResult = runConsumerTest(responsePact,
+                pactConsumerConfig,
+                (mockServer, pactTestExecutionContext) -> {
+                    // Action
+                    try {
+                        response = new ApiBase(mockServer.getUrl(), mockServer.getPort(), "/api")
+                                .get_response(GET, USERS)
+                                .andReturn();
+                    } catch (NullPointerException e) {
+                        log.error("Unable to initialize Response object as null was returned!");
+                    }
+                    return null;
+                });
+
+        if (pactConsumerResult instanceof PactVerificationResult.Error) {
+            throw new RuntimeException(((PactVerificationResult.Error) pactConsumerResult).getError());
+        }
+
+        // Assert
+        response.then().statusCode(200);
+        assertTrue(response.getBody()
+                .jsonPath()
+                .getList("data.first_name")
+                .contains("George"));
+        //assertEquals(new Ok(), pactConsumerResult);
+
+    }
+}

--- a/src/test/java/com/sandeep/api/tests/contract/pact/util/PactUtil.java
+++ b/src/test/java/com/sandeep/api/tests/contract/pact/util/PactUtil.java
@@ -1,0 +1,75 @@
+package com.sandeep.api.tests.contract.pact.util;
+
+import au.com.dius.pact.consumer.ConsumerPactBuilder;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.http.ContentType.JSON;
+
+@Slf4j
+public class PactUtil {
+
+    /**
+     * The method generates a consumer pact file for a get request
+     * @param consumer
+     * @param provider
+     * @param contractDescription
+     * @param path
+     * @return
+     */
+    @NotNull
+    public static RequestResponsePact getGetRequestResponsePact(String consumer, String provider, String contractDescription, String path) {
+        return ConsumerPactBuilder
+                .consumer(consumer)
+                .hasPactWith(provider)
+                .uponReceiving(contractDescription)
+                .path(path)
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .headers(getJsonContentTypeHeader())
+                .body(initJsonBodyFromFile(new File("src/test/resources/test_data/mockData/usersResponse.json")))
+                .toPact();
+    }
+
+
+    /**
+     * The method returns the json body in String format on the basis of the supplied file.
+     * It returns an empty string in case of an exception
+     * @param jsonBodyFile
+     * @return              json string representation from the supplied file
+     */
+    @NotNull
+    public static String initJsonBodyFromFile(File jsonBodyFile) {
+        String jsonBody;
+        try {
+            jsonBody = FileUtils.readFileToString(
+                    jsonBodyFile,
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.error(e.getCause().toString());
+            e.printStackTrace();
+            jsonBody = "";
+        }
+        return jsonBody;
+    }
+
+    /**
+     *
+     * @return  A hashmap of header values
+     */
+    @NotNull
+    public static Map<String, String> getJsonContentTypeHeader() {
+        Map<String, String> pactResponseHeader = new HashMap<>();
+        pactResponseHeader.put("Content-Type", JSON.toString());
+        return pactResponseHeader;
+    }
+}

--- a/src/test/resources/testng_api_suite.xml
+++ b/src/test/resources/testng_api_suite.xml
@@ -6,7 +6,13 @@
         <listener class-name="com.aventstack.extentreports.testng.listener.ExtentITestListenerClassAdapter"/>
     </listeners>
 
-    <test name="API Tests" parallel="classes" thread-count="5">
+    <!--<test name="Pact Contract Tests">
+        <classes>
+            <class name="com.sandeep.api.tests.contract.pact.PactConsumerTest" />
+        </classes>
+    </test>-->
+
+    <test name="API Tests With Virtualization" parallel="classes" thread-count="5">
         <classes>
             <class name="com.sandeep.api.tests.serviceVirtualization.APIMockUsingWireMockTest"/>
             <class name="com.sandeep.api.tests.serviceVirtualization.delayed.APIAwaitilityTest"/>


### PR DESCRIPTION
Consumer contract test added using PACT Consumer. This works with TestNG. The pact is generated and stored in ./target/pacts directory.